### PR TITLE
minimaze cases of trigger AC when no depth streaming

### DIFF
--- a/src/l500/ac-trigger.h
+++ b/src/l500/ac-trigger.h
@@ -129,7 +129,7 @@ namespace ivcam2 {
         // can manually trigger a calibration, meaning that the calibration will run its
         // course and then stop...
         //
-        bool is_on() const { return _is_on; }
+        bool auto_calibration_is_on() const { return _is_on; }
 
         // Start calibration -- after this, is_active() returns true. See the note for is_on().
         void trigger_calibration( bool is_retry = false );


### PR DESCRIPTION
There is a race between stop() function that being called from the sensor and the retry-er thread.
This fix minimize the case where the depth sensor turns off during AC and make sure the RGB sensor will be turn off if needed.