### PR TITLE
Fixed USB ID regular expression

### DIFF
--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -53,7 +53,7 @@ namespace rs2
     public:
         static bool parse_device_id(const std::string& id, device_id* res)
         {
-            static const std::regex regex("pid_([0-9a-f]+)&mi_([0-9]+)#[0-9]&([0-9a-f]+)&[\\s\\S]*\\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\}", std::regex_constants::icase);
+            static const std::regex regex("pid_([0-9a-f]+)&mi_([0-9]+)#[0-9a-f]&([0-9a-f]+)&[\\s\\S]*\\{([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\}", std::regex_constants::icase);
 
             std::match_results<std::string::const_iterator> match;
 


### PR DESCRIPTION
On L515 we found that the metadata_helper ID validation function failed on validation of this USB path:
`\\\\?\\usb#vid_8086&pid_0b64&mi_00#c&2a890e7b&0&0000#{e5323777-f976-4f5b-9b55-b94699c46e44}\\global`