### PR TITLE
Fix exception on non supported CAH devices

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -810,7 +810,7 @@ namespace rs2
         // Needed as a member for reseting the window memory on device disconnection.
        
 
-        cah_model _accuracy_health_model;
+        std::unique_ptr<cah_model> _accuracy_health_model;
         void draw_info_icon(ux_window& window, ImFont* font, const ImVec2& size);
         int draw_seek_bar();
         int draw_playback_controls(ux_window& window, ImFont* font, viewer_model& view);


### PR DESCRIPTION
Adds a check if the device supports calibration for creating CAH model instance

Fixes a bug where non L515 devices are not created.