### PR TITLE
Allow L515 trigger/reset CAH from terminal [Viewer]

### DIFF
--- a/common/cah-model.cpp
+++ b/common/cah-model.cpp
@@ -3,10 +3,7 @@
 
 #include <algorithm>
 #include "cah-model.h"
-#define GLFW_INCLUDE_NONE
-#include "fw-update-helper.h"
 #include "model-views.h"
-#include "types.h"
  
 using namespace rs2;
 

--- a/common/cah-model.h
+++ b/common/cah-model.h
@@ -7,8 +7,6 @@
 #include <chrono>
 #include <atomic>
 
-#include <librealsense2/rs.hpp>
-
 namespace rs2
 {
     class ux_window;

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3379,9 +3379,9 @@ namespace rs2
         , _detected_objects(std::make_shared< atomic_objects_in_frame >()),
         _updates(viewer.updates)
     {
-        if (dev.is<device_calibration>())
+        if( dev.supports( RS2_CAMERA_INFO_FIRMWARE_VERSION ) && dev.is< device_calibration >() )
         {
-            _accuracy_health_model = std::unique_ptr<cah_model>(new cah_model(*this, viewer));
+            _accuracy_health_model = std::unique_ptr< cah_model >( new cah_model( *this, viewer ) );
         }
 
         auto name = get_device_name(dev);
@@ -4790,12 +4790,8 @@ namespace rs2
                 }
             }
 
-            if (dev.supports(RS2_CAMERA_INFO_PRODUCT_LINE) && dev.supports(RS2_CAMERA_INFO_FIRMWARE_VERSION) &&
-                dev.is<device_calibration>())
-            { 
-                auto product_line_str = dev.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
-                if (RS2_PRODUCT_LINE_L500 == parse_product_line(product_line_str))
-                {
+            if (_accuracy_health_model)
+            {
                     if (ImGui::Selectable("Trigger Camera Accuracy Health"))
                     {
                         // We cannot open a pop up window here since we are already in a pop up window
@@ -4807,7 +4803,7 @@ namespace rs2
                     {
                         show_reset_camera_accuracy_health_popup = true;
                     }
-                }
+                
             }
             
             bool has_autocalib = false;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -777,6 +777,7 @@ namespace rs2
 
 
         std::shared_ptr< atomic_objects_in_frame > get_detected_objects() const { return _detected_objects; }
+        bool is_cah_model_enabled() const { return _accuracy_health_model ? true : false; }
 
         std::vector<std::shared_ptr<subdevice_model>> subdevices;
         std::shared_ptr<syncer_model> syncer;
@@ -810,7 +811,9 @@ namespace rs2
         // Needed as a member for reseting the window memory on device disconnection.
        
 
-        std::unique_ptr<cah_model> _accuracy_health_model;
+        std::unique_ptr< cah_model > _accuracy_health_model;  // If this device does not support CAH feature,
+                                                              // the pointer will point to nullptr
+
         void draw_info_icon(ux_window& window, ImFont* font, const ImVec2& size);
         int draw_seek_bar();
         int draw_playback_controls(ux_window& window, ImFont* font, viewer_model& view);

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -22,7 +22,7 @@ void output_model::thread_loop()
             dev_copy = devices;
         }
         if (enable_firmware_logs)
-            for (auto&& dev : devices)
+            for (auto&& dev : dev_copy)
             {
                 try
                 {
@@ -158,7 +158,7 @@ void output_model::open(ux_window& win)
     new_log = true;
 }
 
-void output_model::draw(ux_window& win, rect view_rect, std::vector<rs2::device> devices)
+void output_model::draw(ux_window& win, rect view_rect, device_models_list & device_models)
 {
     ImGui::PushStyleColor(ImGuiCol_FrameBg, scrollbar_bg);
 
@@ -583,7 +583,7 @@ void output_model::draw(ux_window& win, rect view_rect, std::vector<rs2::device>
         {
             if (commands_histroy.size() > 100) commands_histroy.pop_back();
             commands_histroy.push_front(command_line);
-            run_command(command_line, devices);
+            run_command(command_line, device_models);
             command_line = "";
             command_focus = true;
         }
@@ -685,7 +685,9 @@ void output_model::draw(ux_window& win, rect view_rect, std::vector<rs2::device>
 
     {
         std::lock_guard<std::mutex> lock(devices_mutex);
-        this->devices = devices;
+        this->devices.clear();
+        for (auto && dev_model : device_models)
+            this->devices.push_back(dev_model->dev);
     }
 }
 
@@ -751,7 +753,7 @@ void output_model::add_log(rs2_log_severity severity, std::string filename, int 
     new_log = true;
 }
 
-void output_model::run_command(std::string command, std::vector<rs2::device> devices)
+void output_model::run_command(std::string command, device_models_list & device_models)
 {
     try
     {
@@ -771,7 +773,10 @@ void output_model::run_command(std::string command, std::vector<rs2::device> dev
             return;
         }
 
-        std::regex e("([0-9A-Fa-f]{2}\\s)+");
+        if( user_defined_command( command, device_models ) )
+            return;
+
+        std::regex e( "([0-9A-Fa-f]{2}\\s)+" );
 
         if (std::regex_match(command, e))
         {
@@ -863,9 +868,58 @@ void output_model::run_command(std::string command, std::vector<rs2::device> dev
     } 
     catch(const std::exception& ex)
     {
-        add_log(RS2_LOG_SEVERITY_ERROR, __FILE__, __LINE__, ex.what());
+        add_log( RS2_LOG_SEVERITY_ERROR, __FILE__, __LINE__, ex.what() );
     }
 }
+
+bool output_model::user_defined_command( std::string command, device_models_list & device_models )
+{
+    bool user_defined_command_detected = false;
+    bool user_defined_command_activated = false;
+
+    // If a known command is detected , it will treated as a user_defined_command and will not be
+    // passed to the FW commands check logic.
+    // Note: For now we find the first device that supports the command and activate the command only on it.
+
+    if( to_lower( command ) == "trigger-camera-accuracy-health" )
+    {
+        user_defined_command_detected = true;
+
+        for( auto && dev_model : device_models )
+        {
+            if( dev_model->is_cah_model_enabled() && !user_defined_command_activated)
+            {
+                dev_model->show_trigger_camera_accuracy_health_popup = true;
+                user_defined_command_activated = true;
+            }
+        }
+    }
+    else if( to_lower( command ) == "reset-camera-accuracy-health" )
+    {
+        user_defined_command_detected = true;
+
+        for( auto && dev_model : device_models )
+        {
+            if( dev_model->is_cah_model_enabled() && !user_defined_command_activated)
+            {
+                dev_model->show_reset_camera_accuracy_health_popup = true;
+                user_defined_command_activated = true;
+            }
+        }
+    }
+
+    // Log a warning if a known command was not activated
+    if( user_defined_command_detected && ! user_defined_command_activated )
+    {
+        add_log( RS2_LOG_SEVERITY_WARN,
+                 __FILE__,
+                 __LINE__,
+                 to_string() << "None of the connected devices supports '" << command << "'" );
+    }
+
+    return user_defined_command_detected;
+}
+
 
 void output_model::update_dashboards(rs2::frame f)
 {

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -13,6 +13,8 @@
 
 namespace rs2
 {
+    class device_model;
+
     class stream_dashboard
     {
     public:
@@ -29,7 +31,7 @@ namespace rs2
 
         virtual void draw(ux_window& win, rect r) = 0;
 
-        virtual int get_height() const { return 150.f; }
+        virtual int get_height() const { return 150; }
 
         virtual void clear(bool full = false) {}
 
@@ -123,11 +125,13 @@ namespace rs2
 
         void add_log(rs2_log_severity severity, std::string filename, int line_number, std::string line);
 
-        void draw(ux_window& win, rect view_rect, std::vector<rs2::device> devices);
+        void draw(ux_window& win, rect view_rect, std::vector<std::unique_ptr<device_model>> &  device_models);
 
         int get_output_height() const { return default_log_h; }
 
-        void run_command(std::string command, std::vector<rs2::device> devices);
+        void run_command(std::string command, std::vector<std::unique_ptr<device_model>> & device_models);
+        bool user_defined_command(std::string command, std::vector<std::unique_ptr<device_model>> & device_models);
+
 
     private:
         void open(ux_window& win);

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -608,12 +608,7 @@ int main(int argc, const char** argv) try
             window.height() - viewer_model.get_output_height(),
             window.width() - viewer_model.panel_width, viewer_model.get_output_height() };
 
-        std::vector<rs2::device> devices;
-        for (auto&& dev_model : *device_models)
-        {
-            devices.push_back(dev_model->dev);
-        }
-        viewer_model.not_model->output.draw(window, output_rect, devices);
+        viewer_model.not_model->output.draw(window, output_rect, *device_models);
 
         // Set window position and size
         ImGui::SetNextWindowPos({ 0, viewer_model.panel_y });


### PR DESCRIPTION
The terminal commands now support to manual features.
Command >  "trigger-camera-accuracy-health"
Command >  "reset-camera-accuracy-health"

This commands will pop up the related GUI modal is supported.

Currently the command will affect the first device that support the feature from all the connected devices.